### PR TITLE
fixed bug in v.match which was causing it to always return true

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -50,7 +50,7 @@ function handleText(textNode) {
   // Get the corner cases
   if(v.match(/cloud/i)) {
     // If we're not talking about weather
-    if(v.match(/PaaS|SaaS|IaaS|computing|data|storage|cluster|distributed|server|hosting|provider|grid|enterprise|provision|apps|hardware|software|/i)) {
+    if(v.match(/PaaS|SaaS|IaaS|computing|data|storage|cluster|distributed|server|hosting|provider|grid|enterprise|provision|apps|hardware|software/i)) {
       v = v.replace(/(C|c)loud/gi, function(match, p1, offset, string) {
         // c - 1 = b
         b = String.fromCharCode(p1.charCodeAt(0) - 1);


### PR DESCRIPTION
The extra pipe character at the end of the regular expression checking for technology-related words was causing the result of the match to be an array with one empty string when none of the other words was present:

[""]

Therefore, the match was always returning true, and butt was always being converted into butt.

This pull request will fix that bug and cause the expected behavior, but keep in mind that this will cause a lot of false negatives where short nodes are inside larger nodes, like this:

```
<p>Our <em>cloud</em> is not the problem; our local storage is the problem.</p>
```

would render as "Our _cloud_ is not the problem; our local storage is the problem."

but if the <em> tag were removed, then "cloud" would render as "butt" (which is probably what you want), because of the presence of the word "storage" in the <p> tag.

So it's up to you whether to accept this pull request.
