### PR TITLE
No "My butts"; only changes cloud computing references

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -33,7 +33,7 @@ function handleText(textNode) {
 	var v = textNode.nodeValue;
 
   // Deal with the easy case
-  v = v.replace(/\b(T|t)he (C|c)loud/g, function(match, p1, p2, offset, string) {
+  v = v.replace(/\b(T|t)he (C|c)louds?/g, function(match, p1, p2, offset, string) {
     // t - 7 = m
     // c - 1 = b
     m = String.fromCharCode(p1.charCodeAt(0) - 7);
@@ -50,7 +50,7 @@ function handleText(textNode) {
   // Get the corner cases
   if(v.match(/cloud/i)) {
     // If we're not talking about weather
-    if(v.match(/PaaS|SaaS|IaaS|computing|data|storage|cluster|distributed|server|hosting|provider|grid|enterprise|provision|apps|hardware|software|/i)) {
+    if(v.match(/(PaaS|SaaS|IaaS|computing|data|storage|cluster|distributed|server|hosting|provider|grid|enterprise|provision|apps|hardware|software)/i)) {
       v = v.replace(/(C|c)loud/gi, function(match, p1, offset, string) {
         // c - 1 = b
         b = String.fromCharCode(p1.charCodeAt(0) - 1);


### PR DESCRIPTION
Fixed a bug causing every "cloud" to be changed - there was an extra | in the regex expression, which would match anything. Also, every time something like "descended from the clouds" appeared, it would become "descended from my butts". It now changes to "descended from my butt".
