### PR TITLE
Removing dangling | from regular expression

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -50,7 +50,7 @@ function handleText(textNode) {
   // Get the corner cases
   if(v.match(/cloud/i)) {
     // If we're not talking about weather
-    if(v.match(/PaaS|SaaS|IaaS|computing|data|storage|cluster|distributed|server|hosting|provider|grid|enterprise|provision|apps|hardware|software|/i)) {
+    if(v.match(/PaaS|SaaS|IaaS|computing|data|storage|cluster|distributed|server|hosting|provider|grid|enterprise|provision|apps|hardware|software/i)) {
       v = v.replace(/(C|c)loud/gi, function(match, p1, offset, string) {
         // c - 1 = b
         b = String.fromCharCode(p1.charCodeAt(0) - 1);


### PR DESCRIPTION
This extra `|` causes the regular expression to always match any string.

```
> !!'foo'.match(/bar/i)
false
> !!'foo'.match(/bar|/i)
true
```

Alternatively, this entire match could be removed and we can maintain the existing behavior. (I don't personally mind.)
